### PR TITLE
Add metadata to affected personalities

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -27,7 +27,7 @@
       "coui://ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js"
     ]
   },
-  "priority": 50,
+  "priority": 101,
   "titansOnly": true,
   "github": "https://github.com/Quitch/AI-Bugfixes"
 }

--- a/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
+++ b/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
@@ -54,6 +54,18 @@ if (!aiBugfixLoaded) {
       console.error(e);
       console.error(JSON.stringify(e));
     }
+
+    try {
+      for (k in model.aiPersonalities()) {
+        p = model.aiPersonalities()[k]
+        if (!("ai_path" in p) || (p["ai_path"] === "/pa/ai")) {
+          p["qbe"] = true
+        }
+      }
+    } catch (e) {
+      console.error(e);
+      console.error(JSON.stringify(e));
+    }
   }
   aiBugfixPersonalities();
 }


### PR DESCRIPTION
Affected AI personalities will get `"qbe": true` added to their metadata, which allows this information to be seen from the replayfeed.

Priority changed to 101 so that:
1. Queller personalities, which inherit directly from Absurd, do not inherit `"qbe": true`
2. Mods that add new personalities that use the default folder but don't inherit from an existing personality will have `"qbe": true` as long as their priority if 100 or lower.
