### PR TITLE
Add QBE metadata in a safer way

### DIFF
--- a/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
+++ b/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
@@ -6,11 +6,7 @@ if (!aiBugfixLoaded) {
   model.aiPersonalities.subscribe(function () {
     try {
       _.forEach(model.aiPersonalities(), function (value) {
-        // AI personalities will gain a "qbe" property that indicates
-        // if they are affected by this mod or not; this metadata persists
-        // into the replayfeed, game feed, and other sources of data.
-        // This allows systems like Reckoner to differentiate unmodded AIs
-        // from their modded counterparts.
+        // Metadata that persists into feeds to differentiate modded AI from vanilla
         value["qbe"] = !("ai_path" in value) || (value["ai_path"] === "/pa/ai");
       })
     } catch (e) {

--- a/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
+++ b/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
@@ -6,6 +6,11 @@ if (!aiBugfixLoaded) {
   model.aiPersonalities.subscribe(function () {
     try {
       _.forEach(model.aiPersonalities(), function (value) {
+        // AI personalities will gain a "qbe" property that indicates
+        // if they are affected by this mod or not; this metadata persists
+        // into the replayfeed, game feed, and other sources of data.
+        // This allows systems like Reckoner to differentiate unmodded AIs
+        // from their modded counterparts.
         value["qbe"] = !("ai_path" in value) || (value["ai_path"] === "/pa/ai");
       })
     } catch (e) {

--- a/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
+++ b/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
@@ -57,7 +57,7 @@ if (!aiBugfixLoaded) {
   }
   aiBugfixPersonalities();
 
-  model.aiPersonalities.subscribe(function() {
+  function appendQBEMetadata() {
     try {
       for (k in model.aiPersonalities()) {
         p = model.aiPersonalities()[k]
@@ -69,5 +69,8 @@ if (!aiBugfixLoaded) {
       console.error(e);
       console.error(JSON.stringify(e));
     }
-  });
+  };
+  appendQBEMetadata();
+
+  model.aiPersonalities.subscribe(appendQBEMetadata);
 }

--- a/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
+++ b/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
@@ -63,6 +63,8 @@ if (!aiBugfixLoaded) {
         p = model.aiPersonalities()[k]
         if (!("ai_path" in p) || (p["ai_path"] === "/pa/ai")) {
           p["qbe"] = true
+        } else {
+          p["qbe"] = false
         }
       }
     } catch (e) {

--- a/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
+++ b/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
@@ -3,6 +3,17 @@ var aiBugfixLoaded;
 if (!aiBugfixLoaded) {
   aiBugfixLoaded = true;
 
+  model.aiPersonalities.subscribe(function () {
+    try {
+      _.forEach(model.aiPersonalities(), function (value) {
+        value["qbe"] = !("ai_path" in value) || (value["ai_path"] === "/pa/ai");
+      })
+    } catch (e) {
+      console.error(e);
+      console.error(JSON.stringify(e));
+    }
+  });
+
   function aiBugfixPersonalities() {
     try {
       var temp = {};
@@ -56,23 +67,4 @@ if (!aiBugfixLoaded) {
     }
   }
   aiBugfixPersonalities();
-
-  function appendQBEMetadata() {
-    try {
-      for (k in model.aiPersonalities()) {
-        p = model.aiPersonalities()[k]
-        if (!("ai_path" in p) || (p["ai_path"] === "/pa/ai")) {
-          p["qbe"] = true
-        } else {
-          p["qbe"] = false
-        }
-      }
-    } catch (e) {
-      console.error(e);
-      console.error(JSON.stringify(e));
-    }
-  };
-  appendQBEMetadata();
-
-  model.aiPersonalities.subscribe(appendQBEMetadata);
 }

--- a/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
+++ b/ui/mods/com.pa.quitch.AIBugfixEnhancement/difficulty.js
@@ -56,4 +56,18 @@ if (!aiBugfixLoaded) {
     }
   }
   aiBugfixPersonalities();
+
+  model.aiPersonalities.subscribe(function() {
+    try {
+      for (k in model.aiPersonalities()) {
+        p = model.aiPersonalities()[k]
+        if (!("ai_path" in p) || (p["ai_path"] === "/pa/ai")) {
+          p["qbe"] = true
+        }
+      }
+    } catch (e) {
+      console.error(e);
+      console.error(JSON.stringify(e));
+    }
+  });
 }


### PR DESCRIPTION
Similar to #1 , except it's implemented with a subscription to `model.aiPersonalities` so mod priority does not need to be changed.

It runs every time `model.aiPersonalities` mutates, but I've tested it with Queller, AIP, Wondible's AI mod, and 2 of my own (not published) AI personality mods, and each of these mods cause `model.aiPersonalities` to mutate exactly once.
